### PR TITLE
builder-provider-api case study: Fix flipped identifiers in examples

### DIFF
--- a/evaluation/case-studies/builder-provider-api.md
+++ b/evaluation/case-studies/builder-provider-api.md
@@ -101,7 +101,7 @@ struct DefaultCredentialsChain {
 impl DefaultCredentialsChain {
     fn with_custom_credential_source(self, provider: impl ProvideCredentials) {
         // Coerce `impl ProvideCredentials` to `Box<dyn ProvideCredentialsDyn>`
-        Self { provider: Box::new(credentials_source), ..self }
+        Self { credentials_source: Box::new(provider), ..self }
     }
 }
 ```
@@ -125,7 +125,7 @@ impl DefaultCredentialsChain {
         provider: impl ProvideCredentials<provide_credentials(): Send>
     ) {
         // Coerce `impl ProvideCredentials` to `Box<dyn ProvideCredentialsDyn>`
-        Self { provider: Box::new(credentials_source), ..self }
+        Self { credentials_source: Box::new(provider), ..self }
     }
 }
 ```


### PR DESCRIPTION
`provider` is the `fn` argument, while `credentials_source` is the pin-boxed `struct` member.

Side note: 
Line 166 is unchanged. GitHub incorrectly marks it as changed - same as here: https://github.com/rust-lang/async-fundamentals-initiative/pull/6#pullrequestreview-907893260
